### PR TITLE
Bump cloudtrail-s3-bucket module

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -1,6 +1,6 @@
 module "cloudtrail_s3_bucket" {
   source  = "cloudposse/cloudtrail-s3-bucket/aws"
-  version = "0.27.0"
+  version = "0.28.0"
 
   acl                                = var.acl
   expiration_days                    = var.expiration_days


### PR DESCRIPTION
## what
* bump the cloudtrail-s3-bucket module version to latest (`0.28.0`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Terraform module version for CloudTrail S3 bucket to the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->