### PR TITLE
feat: add policy variable to allow custom bucket policy statements

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -9,6 +9,7 @@ module "cloudtrail_s3_bucket" {
   lifecycle_rule_enabled             = var.lifecycle_rule_enabled
   noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
   noncurrent_version_transition_days = var.noncurrent_version_transition_days
+  policy                             = var.policy
   sse_algorithm                      = var.sse_algorithm
   standard_transition_days           = var.standard_transition_days
   versioning_enabled                 = var.versioning_enabled

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -87,3 +87,12 @@ variable "acl" {
     EOT
   default     = "log-delivery-write"
 }
+
+variable "policy" {
+  type        = string
+  default     = ""
+  description = <<-EOT
+    A valid bucket policy JSON document. This policy will be merged with the
+    default CloudTrail bucket policies (AWSCloudTrailAclCheck and AWSCloudTrailWrite).
+    EOT
+}


### PR DESCRIPTION
Exposes the `policy` variable from the underlying `cloudposse/cloudtrail-s3-bucket/aws` module to enable custom bucket policy statements.

This allows cross-account access scenarios where compliance tooling needs bucket-level permissions (e.g., Drata requiring `s3:GetBucketLocation` and `s3:GetBucketLogging`).

The custom policy is merged with default CloudTrail policies (AWSCloudTrailAclCheck and AWSCloudTrailWrite) via `source_policy_documents`. This is a non-breaking change with an empty string default that preserves existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CloudTrail S3 bucket module now accepts a configurable policy parameter, allowing custom bucket policies to be specified and merged with default CloudTrail bucket policies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->