### PR TITLE
feat: add object_lock_configuration support for PCI compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ components:
         expiration_days: 365
 ```
 
+### S3 Object Lock Configuration
+
+For PCI compliance, you can enable S3 Object Lock to store objects using a write-once-read-many (WORM) model.
+
+> **Important**: S3 Object Lock can only be enabled at bucket creation time. It cannot be added to existing buckets.
+
+```yaml
+components:
+  terraform:
+    cloudtrail-bucket:
+      vars:
+        enabled: true
+        name: "cloudtrail"
+        object_lock_configuration:
+          mode: "GOVERNANCE"  # Valid values: GOVERNANCE, COMPLIANCE
+          days: 365
+          years: null
+```
+
 <!-- prettier-ignore-start -->
 <!-- prettier-ignore-end -->
 
@@ -138,6 +157,7 @@ No resources.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_noncurrent_version_expiration_days"></a> [noncurrent\_version\_expiration\_days](#input\_noncurrent\_version\_expiration\_days) | Specifies when noncurrent object versions expire | `number` | `90` | no |
 | <a name="input_noncurrent_version_transition_days"></a> [noncurrent\_version\_transition\_days](#input\_noncurrent\_version\_transition\_days) | Specifies when noncurrent object versions transition to a different storage tier | `number` | `30` | no |
+| <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | A configuration for S3 object locking. With S3 Object Lock, you can store objects using a write-once-read-many (WORM) model. Object lock can help prevent objects from being deleted or overwritten for a fixed amount of time or indefinitely. | <pre>object({<br/>    mode  = string # Valid values are GOVERNANCE and COMPLIANCE.<br/>    days  = number<br/>    years = number<br/>  })</pre> | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | A valid bucket policy JSON document. This policy will be merged with the<br/>default CloudTrail bucket policies (AWSCloudTrailAclCheck and AWSCloudTrailWrite). | `string` | `""` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudtrail_s3_bucket"></a> [cloudtrail\_s3\_bucket](#module\_cloudtrail\_s3\_bucket) | cloudposse/cloudtrail-s3-bucket/aws | 0.29.0 |
+| <a name="module_cloudtrail_s3_bucket"></a> [cloudtrail\_s3\_bucket](#module\_cloudtrail\_s3\_bucket) | cloudposse/cloudtrail-s3-bucket/aws | 0.30.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/README.yaml
+++ b/README.yaml
@@ -26,6 +26,25 @@ usage: |-
           expiration_days: 365
   ```
 
+  ### S3 Object Lock Configuration
+
+  For PCI compliance, you can enable S3 Object Lock to store objects using a write-once-read-many (WORM) model.
+
+  > **Important**: S3 Object Lock can only be enabled at bucket creation time. It cannot be added to existing buckets.
+
+  ```yaml
+  components:
+    terraform:
+      cloudtrail-bucket:
+        vars:
+          enabled: true
+          name: "cloudtrail"
+          object_lock_configuration:
+            mode: "GOVERNANCE"  # Valid values: GOVERNANCE, COMPLIANCE
+            days: 365
+            years: null
+  ```
+
   <!-- prettier-ignore-start -->
   <!-- prettier-ignore-end -->
 references:

--- a/src/README.md
+++ b/src/README.md
@@ -31,6 +31,25 @@ components:
         expiration_days: 365
 ```
 
+### S3 Object Lock Configuration
+
+For PCI compliance, you can enable S3 Object Lock to store objects using a write-once-read-many (WORM) model.
+
+> **Important**: S3 Object Lock can only be enabled at bucket creation time. It cannot be added to existing buckets.
+
+```yaml
+components:
+  terraform:
+    cloudtrail-bucket:
+      vars:
+        enabled: true
+        name: "cloudtrail"
+        object_lock_configuration:
+          mode: "GOVERNANCE"  # Valid values: GOVERNANCE, COMPLIANCE
+          days: 365
+          years: null
+```
+
 <!-- prettier-ignore-start -->
 <!-- prettier-ignore-end -->
 
@@ -86,6 +105,7 @@ No resources.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_noncurrent_version_expiration_days"></a> [noncurrent\_version\_expiration\_days](#input\_noncurrent\_version\_expiration\_days) | Specifies when noncurrent object versions expire | `number` | `90` | no |
 | <a name="input_noncurrent_version_transition_days"></a> [noncurrent\_version\_transition\_days](#input\_noncurrent\_version\_transition\_days) | Specifies when noncurrent object versions transition to a different storage tier | `number` | `30` | no |
+| <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | A configuration for S3 object locking. With S3 Object Lock, you can store objects using a write-once-read-many (WORM) model. Object lock can help prevent objects from being deleted or overwritten for a fixed amount of time or indefinitely. | <pre>object({<br/>    mode  = string # Valid values are GOVERNANCE and COMPLIANCE.<br/>    days  = number<br/>    years = number<br/>  })</pre> | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | A valid bucket policy JSON document. This policy will be merged with the<br/>default CloudTrail bucket policies (AWSCloudTrailAclCheck and AWSCloudTrailWrite). | `string` | `""` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |

--- a/src/README.md
+++ b/src/README.md
@@ -70,7 +70,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudtrail_s3_bucket"></a> [cloudtrail\_s3\_bucket](#module\_cloudtrail\_s3\_bucket) | cloudposse/cloudtrail-s3-bucket/aws | 0.29.0 |
+| <a name="module_cloudtrail_s3_bucket"></a> [cloudtrail\_s3\_bucket](#module\_cloudtrail\_s3\_bucket) | cloudposse/cloudtrail-s3-bucket/aws | 0.30.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,6 +1,6 @@
 module "cloudtrail_s3_bucket" {
   source  = "cloudposse/cloudtrail-s3-bucket/aws"
-  version = "0.29.0"
+  version = "0.30.0"
 
   acl                                = var.acl
   expiration_days                    = var.expiration_days

--- a/src/main.tf
+++ b/src/main.tf
@@ -9,6 +9,7 @@ module "cloudtrail_s3_bucket" {
   lifecycle_rule_enabled             = var.lifecycle_rule_enabled
   noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
   noncurrent_version_transition_days = var.noncurrent_version_transition_days
+  object_lock_configuration          = var.object_lock_configuration
   policy                             = var.policy
   sse_algorithm                      = var.sse_algorithm
   standard_transition_days           = var.standard_transition_days

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -96,3 +96,13 @@ variable "policy" {
     default CloudTrail bucket policies (AWSCloudTrailAclCheck and AWSCloudTrailWrite).
     EOT
 }
+
+variable "object_lock_configuration" {
+  type = object({
+    mode  = string # Valid values are GOVERNANCE and COMPLIANCE.
+    days  = number
+    years = number
+  })
+  default     = null
+  description = "A configuration for S3 object locking. With S3 Object Lock, you can store objects using a write-once-read-many (WORM) model. Object lock can help prevent objects from being deleted or overwritten for a fixed amount of time or indefinitely."
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -106,3 +106,10 @@ variable "object_lock_configuration" {
   default     = null
   description = "A configuration for S3 object locking. With S3 Object Lock, you can store objects using a write-once-read-many (WORM) model. Object lock can help prevent objects from being deleted or overwritten for a fixed amount of time or indefinitely."
 }
+
+check "object_lock_requires_versioning" {
+  assert {
+    condition     = var.object_lock_configuration == null || var.versioning_enabled == true
+    error_message = "S3 Object Lock requires versioning_enabled = true. When object_lock_configuration is set, versioning_enabled must be true."
+  }
+}


### PR DESCRIPTION
## Summary
Add pass-through support for S3 Object Lock configuration to enable write-once-read-many (WORM) model for CloudTrail logs. This is required for PCI compliance. The underlying cloudposse/s3-bucket module already supports this feature.

## Changes
- Add `object_lock_configuration` variable to `src/variables.tf`
- Pass through variable in `src/main.tf` module call
- Update documentation with usage examples and important notes about bucket creation limitations

## Testing
Verify with configuration including:
```hcl
object_lock_configuration = {
  mode  = "GOVERNANCE"
  days  = 365
  years = null
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added S3 Object Lock Configuration guide explaining WORM behavior, supported modes (GOVERNANCE, COMPLIANCE), that Object Lock must be enabled at bucket creation, and includes usage examples.

* **New Features**
  * Added S3 Object Lock support with configurable retention (mode, days, years) exposed as a public input.

* **Bug Fixes / Validation**
  * Enforced that Object Lock requires versioning to be enabled when configured.

* **Chores**
  * Bumped module version to 0.30.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->